### PR TITLE
chore: update iconfont resource url regx

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ const { promisify } = require('util')
 const got = require('got')
 const ora = require('ora')
 
-const iconFontCNCssRegex = /\/\/at\.alicdn\.com\/t\/a\/font\w+\.css/i
+const iconFontCNCssRegex = /\/\/at\.alicdn\.com\/t\/(a\/)?font\w+\.css/i
 
 // eslint-disable-next-line node/no-deprecated-api
 const fsReadFile = promisify(fs.readFile)

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ const { promisify } = require('util')
 const got = require('got')
 const ora = require('ora')
 
-const iconFontCNCssRegex = /\/\/at\.alicdn\.com\/t\/font\w+\.css/i
+const iconFontCNCssRegex = /\/\/at\.alicdn\.com\/t\/a\/font\w+\.css/i
 
 // eslint-disable-next-line node/no-deprecated-api
 const fsReadFile = promisify(fs.readFile)


### PR DESCRIPTION
The new version of the iconfont resource url changed to be `//at.alicdn.com/t/a/font_1432262_0gpk8o1jvjfn.css` formate.